### PR TITLE
fix deprecated set-output

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -26,8 +26,8 @@ jobs:
       id: cache-setup
       run: |
         mkdir -p "$HOME"/.cache/xml2rfc
-        echo "::set-output name=path::$HOME/.cache/xml2rfc"
-        date -u "+::set-output name=date::%FT%T"
+        echo "path=$HOME/.cache/xml2rfc" >> $GITHUB_OUTPUT
+        date -u "+date=%FT%T" >> $GITHUB_OUTPUT
 
     - name: "Cache References"
       uses: actions/cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,8 +21,8 @@ jobs:
       id: cache-setup
       run: |
         mkdir -p "$HOME"/.cache/xml2rfc
-        echo "::set-output name=path::$HOME/.cache/xml2rfc"
-        date -u "+::set-output name=date::%FT%T"
+        echo "path=$HOME/.cache/xml2rfc" >> $GITHUB_OUTPUT
+        date -u "+date=%FT%T" >> $GITHUB_OUTPUT
 
     - name: "Cache References"
       uses: actions/cache@v2

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -27,7 +27,7 @@ jobs:
           echo "Commit the changes to the 'main' branch."
           echo
           echo "============================================================="
-          echo "::set-output name=skip::true"
+          echo "skip=true" >> $GITHUB_OUTPUT
         elif [ ! -f draft-todo-yourname-protocol.md -a -f Makefile ]; then
           echo "============================================================="
           echo "Skipping setup for an already-configured repository."
@@ -37,7 +37,7 @@ jobs:
           echo "    https://github.com/${{github.repository}}/delete/main/.github/workflows/setup.yml"
           echo
           echo "============================================================="
-          echo "::set-output name=skip::true"
+          echo "skip=true" >> $GITHUB_OUTPUT
         fi
 
     - name: "Git Config"


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Bob Callaway <bcallaway@google.com>
