### PR TITLE
Clarified that verification using DSSE.

### DIFF
--- a/client-spec.md
+++ b/client-spec.md
@@ -231,7 +231,9 @@ The Verifier now constructs the payload to be signed from the artifact and the a
 
 * Using the raw bytes of the artifact as the payload.
 * Hashing the artifact, then using the resultant digest as the payload.
-* Using [DSSE](https://github.com/secure-systems-lab/dsse/blob/master/protocol.md) as an envelope for the payload which MUST be an in-toto statement.
+* Using [DSSE](https://github.com/secure-systems-lab/dsse/blob/master/protocol.md) as an envelope for the payload.
+    * The DSSE `payloadType` must be `application/vnd.in-toto+json` per the [in-toto Envelope layer specification](https://github.com/in-toto/attestation/blob/main/spec/v1/envelope.md).
+    * The payload MUST be an [in-toto statement](https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md).
     * Verifier MUST ensure that the artifact's digest/algorithm tuple is present in the list of subjects in the in-toto statement.
     * Verifier SHOULD accept the raw artifact and compute the message digest to minimize any risk for confusion attacks.
 

--- a/client-spec.md
+++ b/client-spec.md
@@ -232,7 +232,7 @@ The Verifier now constructs the payload to be signed from the artifact and the a
 * Using the raw bytes of the artifact as the payload.
 * Hashing the artifact, then using the resultant digest as the payload.
 * Using [DSSE](https://github.com/secure-systems-lab/dsse/blob/master/protocol.md) as an envelope for the payload which MUST be an in-toto statement.
-    * Verifier MUST ensure that the artifact's digest/alg tuple is present in the list of subject in the in-toto statement.
+    * Verifier MUST ensure that the artifact's digest/algorithm tuple is present in the list of subjects in the in-toto statement.
     * Verifier SHOULD accept the raw artifact and compute the message digest to minimize any risk for confusion attacks.
 
 The Verifier MUST verify the provided signature for the constructed payload against the key in the leaf of the certificate chain.

--- a/client-spec.md
+++ b/client-spec.md
@@ -231,7 +231,9 @@ The Verifier now constructs the payload to be signed from the artifact and the a
 
 * Using the raw bytes of the artifact as the payload.
 * Hashing the artifact, then using the resultant digest as the payload.
-* Using [DSSE](https://github.com/secure-systems-lab/dsse/blob/master/protocol.md) as an envelope for the payload with a known DSSE payload type.
+* Using [DSSE](https://github.com/secure-systems-lab/dsse/blob/master/protocol.md) as an envelope for the payload which MUST be an in-toto statement.
+    * Verifier MUST ensure that the artifact's digest/alg tuple is present in the list of subject in the in-toto statement.
+    * Verifier SHOULD accept the raw artifact and compute the message digest to minimize any risk for confusion attacks.
 
 The Verifier MUST verify the provided signature for the constructed payload against the key in the leaf of the certificate chain.
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Clarified that verification using DSSE:
* Payload must be an in-toto statement
* Verifier must ensure the artifact's digest is present as a subject

This was discussed at the Sigstore client's meeting @ 2025-01-07 

Note that I didn't adda a section that clients MAY verify using a pre-computed digest. As the current wording is _SHOULD accept a raw artifact_, I think it is enough. This relates to https://github.com/sigstore/protobuf-specs/issues/444

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Clarified that when verifying using a DSSE envelope, the payload must be an in-toto statement.
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
This only relates to documentation.

cc @loosebazooka @woodruffw @steiza @haydentherapper @tracymiranda