### PR TITLE
specs: add algorithm-registry.md

### DIFF
--- a/algorithm-registry.md
+++ b/algorithm-registry.md
@@ -1,0 +1,64 @@
+# Algorithm Registry
+
+This file is designed to act as a source of truth regarding what signing
+algorithms are recommended across the Sigstore ecosystem. Any changes to this
+file **must** be reflected in the `PublicKeyDetails` enumeration in
+[`sigstore_common.proto`] in [sigstore/protobuf-specs].
+
+Sigstore clients aren't required to support all algorithms in this registry,
+and **MAY** support algorithms that aren't in the registry. However,
+compatibility with the Sigstore Public Good Instance requires support
+for at least one of these algorithms.
+
+## Signature Algorithms
+
+| Algorithm | Name                       | Usage       | Notes                                                                            |
+|-----------|----------------------------|-------------| -------------------------------------------------------------------------------- |
+| RSA       | rsa-sign-pkcs1-2048-sha256 | verify only | Not recommended.                                                                 |
+|           | rsa-sign-pkcs1-3072-sha256 | sign/verify |                                                                                  |
+|           | rsa-sign-pkcs1-4096-sha256 | sign/verify |                                                                                  |
+|           | rsa-sign-pss-2048-sha256   | verify only | Not recommended.                                                                 |
+|           | rsa-sign-pss-3072-sha256   | sign/verify |                                                                                  |
+|           | rsa-sign-pss-4096-sha256   | sign/verify |                                                                                  |
+| ECDSA     | ecdsa-sha2-256-nistp256    | sign/verify |                                                                                  |
+|           | ecdsa-sha2-384-nistp384    | sign/verify |                                                                                  |
+|           | ecdsa-sha2-512-nistp521    | sign/verify |                                                                                  |
+| EdDSA     | ed25519                    | sign/verify |                                                                                  |
+|           | ed25519-ph                 | sign/verify | Recommended only for `hashedrekord`.                                             |
+| LMS       | lms-sha256                 | sign/verify | Stateful; signer selects the `H` parameter. Not recommended for keyless signing. |
+| LM-OTS    | lmots-sha256               | sign/verify | One-time use only; signer selects `n` and `w`.                                   |
+
+### Parameter configuration for LMS and LM-OTS
+
+LMS and LM-OTS are both hash-based signature schemes. Both require the signing party
+to make parameter choices during key generation.
+
+In both cases, the selected parameters are encoded in the public key representation.
+See [RFC 8554 S5.3](https://www.rfc-editor.org/rfc/rfc8554.html#section-5.3) for LMS and
+[RFC 8554 S4.3](https://www.rfc-editor.org/rfc/rfc8554.html#section-4.3) for LM-OTS public key
+formats. Additionally, see [RFC 8708 S4](https://www.rfc-editor.org/rfc/rfc8708.html) for
+`SubjectPublicKeyInfo` and `AlgorithmIdentifier` encodings for both LMS and LM-OTS
+public keys.
+
+## Hash Algorithms
+
+Generally speaking, these hash algorithms are implied by the above signing suites.
+However, clients *may* need to list or configure them explicitly, e.g. for custom
+signing schemes or as part of a `hashedrekord` entry.
+
+| Algorithm | Name         |
+|-----------|--------------|
+| SHA2      | sha2-256     |
+|           | sha2-384     |
+|           | sha2-512     |
+| SHA3      | sha3-256     |
+|           | sha3-384     |
+
+[`sigstore_common.proto`]: https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_common.proto
+
+[sigstore/protobuf-specs]: https://github.com/sigstore/protobuf-specs
+
+### History
+
+See [Sigstore: Configurable Crypto Algorithms](https://docs.google.com/document/d/18vTKFvTQdRt3OGz6Qd1xf04o-hugRYSup-1EAOWn7MQ/)
+specification for the design rationale for this registry.

--- a/client-spec.md
+++ b/client-spec.md
@@ -64,7 +64,13 @@ At the conclusion of the authentication protocol, the Signer will possess an aut
 
 #### 2.1.2. Key Generation
 
-The Signer chooses an algorithm for digital signatures from the registry ([Spec: Sigstore Registries](https://docs.google.com/document/d/1wYYOtpyuWaDaIrjF1eyaH1iJueE_lvQPk_uwfwbMSoA/edit#heading=h.if88xkt0tyir)); the chosen algorithm MUST be in both the Fulcio instance’s and the Transparency Service instance’s `supportedSigningAlgorithms`). The Signer generates a signing/verification key pair via the appropriate key generation procedure. The Signer MAY store the signing key on a secure hardware device. Regardless of the success of the signing procedure, the signer SHOULD destroy the keypair at the end.
+The Signer chooses an algorithm for digital signatures from the registry
+([Spec: Algorithm Registry](./algorithm-registry.md)); the chosen algorithm MUST be in
+both the Fulcio instance’s and the Transparency Service instance’s
+`supportedSigningAlgorithms`). The Signer generates a signing/verification key
+pair via the appropriate key generation procedure. The Signer MAY store the
+signing key on a secure hardware device. Regardless of the success of the
+signing procedure, the signer SHOULD destroy the keypair at the end.
 
 #### 2.1.3. Certificate Issuance
 


### PR DESCRIPTION
This adds the algorithm registry documentation to this
repo, copied mostly verbatim from sigstore/protobuf-specs.

My thinking is to get this merged first, then iterate on
the PQ and agility changes that have stacked up.

Old doc for reference: https://github.com/sigstore/protobuf-specs/blob/2136b2784bbb434bcf02d345a06e53d47cb6814e/docs/algorithm-registry.md

Signed-off-by: William Woodruff <william@trailofbits.com>


xrefs:

* https://github.com/sigstore/protobuf-specs/issues/566
* https://github.com/sigstore/sig-clients/issues/16